### PR TITLE
Added Fedora compatibility info to README.md file

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@
 
 ## Compatibility
 This should work on any Linux distribution that uses GRUB, but I have only tested it on EndeavourOS and Kali
+### For Fedora 37
+Comment out `'GRUB_TERMINAL_OUTPUT="console"` line in your `/etc/default/grub` file.
 
 ## Install
 ```bash


### PR DESCRIPTION
When I first followed your [installation guide](https://github.com/AllJavi/tartarus-grub#install) it didn't work. So I search for the specific issue for fedora and found [this](https://ask.fedoraproject.org/t/i-cant-change-the-grub-theme/4724) thread where I found the solution. So I've added line under compatibility section to the README.md. Hope this will be helpful.